### PR TITLE
Add GitHub Actions workflow for Python tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,11 +22,10 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip>=25.1"
           if [ -f pyproject.toml ]; then
-            pip install "pip-tools>=7.0"
-            pip-compile --extra dev --output-file=requirements-dev.txt pyproject.toml
-            pip install -r requirements-dev.txt
+            # Install the development dependency group defined in pyproject.toml (PEP 735)
+            pip install --group dev
           else
             pip install pytest pytest-asyncio
           fi


### PR DESCRIPTION
This PR adds a basic CI pipeline to run the Python tests for BLT Byte.

### What’s included

- Adds `.github/workflows/tests.yml`:
  - Triggers on pushes to `main` / `master` and on all pull requests.
  - Uses Python 3.12 to match `pyproject.toml`.
  - Installs dev dependencies from `pyproject.toml` (the `dev` extra) via `pip-compile` → `requirements-dev.txt`.
  - Runs `python -m pytest tests/ -v`.

### Rationale

- Ensures test failures are caught automatically on every PR.
- Aligns the CI Python version and dependencies with the local development setup.

### Testing

- Ran `python -m pytest tests/ -v` locally; all tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated CI to run Python tests on pushes and pull requests.
  * CI uses Python 3.12, installs project test dependencies, and runs the test suite with pytest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->