### PR TITLE
fix: 500 server error in the chatbot

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -598,7 +598,7 @@ def _get_onboarding_guide(role: str) -> dict:
 # Main Worker entrypoint
 # ---------------------------------------------------------------------------
 class Default(WorkerEntrypoint):
-    async def fetch(self, request) -> Response:
+    async def on_fetch(self, request) -> Response:
         try:
             return await self._handle(request)
         except Exception as exc:


### PR DESCRIPTION
### Fixed 500 Server Error
Fixed 500 error, making the chatbot workable.

api/chat was making request to fetch() function when it was looking for on_fetch(). By changing the function name, the chatbot is now operational.

**Before:**
<img width="1258" height="312" alt="Screenshot 2026-03-15 141751" src="https://github.com/user-attachments/assets/b1c55a41-a8f9-4894-88d5-feef2b5a298a" />

**After:**
<img width="1563" height="710" alt="Screenshot 2026-03-15 143506" src="https://github.com/user-attachments/assets/8083991e-eacf-4239-8bf8-7400b8610214" />


